### PR TITLE
NPDOTF-444

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,46 +35,46 @@ message( STATUS "## Build Type            (Debug|Release) : ${CMAKE_BUILD_TYPE}"
 ####################################################
 
 ####Raspberry-Pi 3 selection-Without ODS
-add_definitions( -DTS_SERVICE_TS_CBOR )     	# TS_JSON, TS_CBOR or CUSTOM
-add_definitions( -DTS_TRANSPORT_MQTT )      	# MQTT or CUSTOM
-add_definitions( -DTS_SECURITY_MBED )      	# MBED, MOCANA, NONE or CUSTOM
-add_definitions( -DTS_CONTROLLER_NONE )     	# MONARCH, NONE or CUSTOM
-add_definitions( -DTS_FIREWALL_NONE )       	# NONE or CUSTOM 
-add_definitions( -DTS_MUTEX_NONE )          	# NONE or CUSTOM 
+add_definitions( -DTS_SERVICE_TS_CBOR )		# TS_JSON or TS_CBOR
+add_definitions( -DTS_TRANSPORT_MQTT )		# MQTT or CUSTOM
+add_definitions( -DTS_SECURITY_MBED )		# MBED or CUSTOM
+add_definitions( -DTS_CONTROLLER_NONE )		# MONARCH, NONE or CUSTOM
+add_definitions( -DTS_FIREWALL_NONE )		# NONE or CUSTOM 
+add_definitions( -DTS_MUTEX_NONE )		# NONE or CUSTOM 
 
 # Raspberry-Pi 3 selection-With ODS
-# add_definitions( -DTS_SERVICE_TS_CBOR )     	# TS_JSON, TS_CBOR or CUSTOM
-# add_definitions( -DTS_TRANSPORT_MQTT )      	# MQTT or CUSTOM
-# add_definitions( -DTS_SECURITY_CUSTOM )       # MBED, MOCANA, NONE or CUSTOM
-# add_definitions( -DTS_CONTROLLER_CUSTOM )    	# MONARCH, NONE or CUSTOM
-# add_definitions( -DTS_FIREWALL_CUSTOM )       # NONE or CUSTOM 
-# add_definitions( -DTS_MUTEX_CUSTOM )          # NONE or CUSTOM
-# add_definitions( -DTS_SCEP_CUSTOM )			# NONE or CUSTOM
+# add_definitions( -DTS_SERVICE_TS_CBOR )	# TS_JSON or TS_CBOR
+# add_definitions( -DTS_TRANSPORT_MQTT )	# MQTT or CUSTOM
+# add_definitions( -DTS_SECURITY_CUSTOM )	# MBED or CUSTOM
+# add_definitions( -DTS_CONTROLLER_CUSTOM)	# MONARCH, NONE or CUSTOM
+# add_definitions( -DTS_FIREWALL_CUSTOM )	# NONE or CUSTOM 
+# add_definitions( -DTS_MUTEX_CUSTOM )		# NONE or CUSTOM
+# add_definitions( -DTS_SCEP_CUSTOM )		# NONE or CUSTOM
 
 #### Renesas PK - S5D9 selection-With ODS
-# add_definitions( -DTS_SERVICE_TS_CBOR )     	# TS_JSON, TS_CBOR or CUSTOM
-# add_definitions( -DTS_TRANSPORT_MQTT )      	# MQTT or CUSTOM
-# add_definitions( -DTS_SECURITY_CUSTOM )       # MBED, MOCANA, NONE or CUSTOM
-# add_definitions( -DTS_CONTROLLER_CUSTOM )    	# MONARCH, NONE or CUSTOM
-# add_definitions( -DTS_FIREWALL_CUSTOM )       # NONE or CUSTOM 
-# add_definitions( -DTS_MUTEX_NONE )          	# NONE or CUSTOM
-# add_definitions( -DTS_SCEP_CUSTOM )			# NONE or CUSTOM
+# add_definitions( -DTS_SERVICE_TS_CBOR )	# TS_JSON or TS_CBOR
+# add_definitions( -DTS_TRANSPORT_MQTT )	# MQTT or CUSTOM
+# add_definitions( -DTS_SECURITY_CUSTOM )	# MBED or CUSTOM
+# add_definitions( -DTS_CONTROLLER_CUSTOM )	# MONARCH, NONE or CUSTOM
+# add_definitions( -DTS_FIREWALL_CUSTOM )	# NONE or CUSTOM 
+# add_definitions( -DTS_MUTEX_NONE )		# NONE or CUSTOM
+# add_definitions( -DTS_SCEP_CUSTOM )		# NONE or CUSTOM
 
 #### ST Micro selection 
-# add_definitions( -DTS_SERVICE_TS_JSON )     	# TS_JSON, TS_CBOR or CUSTOM
-# add_definitions( -DTS_TRANSPORT_MQTT )      	# MQTT or CUSTOM
-# add_definitions( -DTS_SECURITY_MBED )       	# MBED, MOCANA, NONE or CUSTOM
-# add_definitions( -DTS_CONTROLLER_MONARCH )    # MONARCH, NONE or CUSTOM
-# add_definitions( -DTS_FIREWALL_NONE )       	# NONE or CUSTOM 
-# add_definitions( -DTS_MUTEX_NONE )          	# NONE or CUSTOM
+# add_definitions( -DTS_SERVICE_TS_JSON )	# TS_JSON or TS_CBOR
+# add_definitions( -DTS_TRANSPORT_MQTT )	# MQTT or CUSTOM
+# add_definitions( -DTS_SECURITY_MBED )		# MBED or CUSTOM
+# add_definitions( -DTS_CONTROLLER_MONARCH )	# MONARCH, NONE or CUSTOM
+# add_definitions( -DTS_FIREWALL_NONE )		# NONE or CUSTOM 
+# add_definitions( -DTS_MUTEX_NONE )		# NONE or CUSTOM
 
 #### NXP selection 
-# add_definitions( -DTS_SERVICE_TS_JSON )     	# TS_JSON, TS_CBOR or CUSTOM
-# add_definitions( -DTS_TRANSPORT_MQTT )      	# MQTT or CUSTOM
-# add_definitions( -DTS_SECURITY_MBED )       	# MBED, MOCANA, NONE or CUSTOM
-# add_definitions( -DTS_CONTROLLER_MONARCH )    # MONARCH, NONE or CUSTOM
-# add_definitions( -DTS_FIREWALL_NONE )       	# NONE or CUSTOM 
-# add_definitions( -DTS_MUTEX_NONE )          	# NONE or CUSTOM
+# add_definitions( -DTS_SERVICE_TS_JSON )	# TS_JSON or TS_CBOR
+# add_definitions( -DTS_TRANSPORT_MQTT )	# MQTT or CUSTOM
+# add_definitions( -DTS_SECURITY_MBED )		# MBED, MOCANA, NONE or CUSTOM
+# add_definitions( -DTS_CONTROLLER_MONARCH )	# MONARCH, NONE or CUSTOM
+# add_definitions( -DTS_FIREWALL_NONE )		# NONE or CUSTOM 
+# add_definitions( -DTS_MUTEX_NONE )		# NONE or CUSTOM
 
 # build vendor libraries
 add_definitions( -D__GLIBC__ )              # TODO, remove tinyCBOR HACK

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ message( STATUS "## Build Type            (Debug|Release) : ${CMAKE_BUILD_TYPE}"
 
 ####Raspberry-Pi 3 selection-Without ODS
 add_definitions( -DTS_SERVICE_TS_CBOR )		# TS_JSON or TS_CBOR
-add_definitions( -DTS_TRANSPORT_MQTT )		# MQTT or CUSTOM
+add_definitions( -DTS_TRANSPORT_MQTT )		# MQTT
 add_definitions( -DTS_SECURITY_MBED )		# MBED or CUSTOM
 add_definitions( -DTS_CONTROLLER_NONE )		# MONARCH, NONE or CUSTOM
 add_definitions( -DTS_FIREWALL_NONE )		# NONE or CUSTOM 
@@ -44,7 +44,7 @@ add_definitions( -DTS_MUTEX_NONE )		# NONE or CUSTOM
 
 # Raspberry-Pi 3 selection-With ODS
 # add_definitions( -DTS_SERVICE_TS_CBOR )	# TS_JSON or TS_CBOR
-# add_definitions( -DTS_TRANSPORT_MQTT )	# MQTT or CUSTOM
+# add_definitions( -DTS_TRANSPORT_MQTT )	# MQTT
 # add_definitions( -DTS_SECURITY_CUSTOM )	# MBED or CUSTOM
 # add_definitions( -DTS_CONTROLLER_CUSTOM)	# MONARCH, NONE or CUSTOM
 # add_definitions( -DTS_FIREWALL_CUSTOM )	# NONE or CUSTOM 
@@ -53,7 +53,7 @@ add_definitions( -DTS_MUTEX_NONE )		# NONE or CUSTOM
 
 #### Renesas PK - S5D9 selection-With ODS
 # add_definitions( -DTS_SERVICE_TS_CBOR )	# TS_JSON or TS_CBOR
-# add_definitions( -DTS_TRANSPORT_MQTT )	# MQTT or CUSTOM
+# add_definitions( -DTS_TRANSPORT_MQTT )	# MQTT
 # add_definitions( -DTS_SECURITY_CUSTOM )	# MBED or CUSTOM
 # add_definitions( -DTS_CONTROLLER_CUSTOM )	# MONARCH, NONE or CUSTOM
 # add_definitions( -DTS_FIREWALL_CUSTOM )	# NONE or CUSTOM 
@@ -62,7 +62,7 @@ add_definitions( -DTS_MUTEX_NONE )		# NONE or CUSTOM
 
 #### ST Micro selection 
 # add_definitions( -DTS_SERVICE_TS_JSON )	# TS_JSON or TS_CBOR
-# add_definitions( -DTS_TRANSPORT_MQTT )	# MQTT or CUSTOM
+# add_definitions( -DTS_TRANSPORT_MQTT )	# MQTT
 # add_definitions( -DTS_SECURITY_MBED )		# MBED or CUSTOM
 # add_definitions( -DTS_CONTROLLER_MONARCH )	# MONARCH, NONE or CUSTOM
 # add_definitions( -DTS_FIREWALL_NONE )		# NONE or CUSTOM 
@@ -70,8 +70,8 @@ add_definitions( -DTS_MUTEX_NONE )		# NONE or CUSTOM
 
 #### NXP selection 
 # add_definitions( -DTS_SERVICE_TS_JSON )	# TS_JSON or TS_CBOR
-# add_definitions( -DTS_TRANSPORT_MQTT )	# MQTT or CUSTOM
-# add_definitions( -DTS_SECURITY_MBED )		# MBED, MOCANA, NONE or CUSTOM
+# add_definitions( -DTS_TRANSPORT_MQTT )	# MQTT
+# add_definitions( -DTS_SECURITY_MBED )		# MBED or CUSTOM
 # add_definitions( -DTS_CONTROLLER_MONARCH )	# MONARCH, NONE or CUSTOM
 # add_definitions( -DTS_FIREWALL_NONE )		# NONE or CUSTOM 
 # add_definitions( -DTS_MUTEX_NONE )		# NONE or CUSTOM

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,14 +30,51 @@ endif()
 
 message( STATUS "## Build Type            (Debug|Release) : ${CMAKE_BUILD_TYPE}" )
 
-# component selection
-add_definitions( -DTS_SERVICE_TS_JSON )     # TS_JSON, TS_CBOR or CUSTOM
-add_definitions( -DTS_TRANSPORT_MQTT )      # MQTT or CUSTOM
-add_definitions( -DTS_SECURITY_MBED )       # MBED, MOCANA, NONE or CUSTOM
-add_definitions( -DTS_CONTROLLER_NONE )     # MONARCH, NONE or CUSTOM
-add_definitions( -DTS_FIREWALL_NONE )       # NONE or CUSTOM (rarely used)
-add_definitions( -DTS_MUTEX_NONE )          # NONE or CUSTOM (rarely used)
-add_definitions( -DTS_SCEP_NONE )         # NONE or CUSTOM (rarely used)
+####################################################
+#Uncomment the section corresponding to the platform 
+####################################################
+
+####Raspberry-Pi 3 selection-Without ODS
+add_definitions( -DTS_SERVICE_TS_CBOR )     	# TS_JSON, TS_CBOR or CUSTOM
+add_definitions( -DTS_TRANSPORT_MQTT )      	# MQTT or CUSTOM
+add_definitions( -DTS_SECURITY_MBED )      	# MBED, MOCANA, NONE or CUSTOM
+add_definitions( -DTS_CONTROLLER_NONE )     	# MONARCH, NONE or CUSTOM
+add_definitions( -DTS_FIREWALL_NONE )       	# NONE or CUSTOM 
+add_definitions( -DTS_MUTEX_NONE )          	# NONE or CUSTOM 
+
+# Raspberry-Pi 3 selection-With ODS
+# add_definitions( -DTS_SERVICE_TS_CBOR )     	# TS_JSON, TS_CBOR or CUSTOM
+# add_definitions( -DTS_TRANSPORT_MQTT )      	# MQTT or CUSTOM
+# add_definitions( -DTS_SECURITY_CUSTOM )       # MBED, MOCANA, NONE or CUSTOM
+# add_definitions( -DTS_CONTROLLER_CUSTOM )    	# MONARCH, NONE or CUSTOM
+# add_definitions( -DTS_FIREWALL_CUSTOM )       # NONE or CUSTOM 
+# add_definitions( -DTS_MUTEX_CUSTOM )          # NONE or CUSTOM
+# add_definitions( -DTS_SCEP_CUSTOM )			# NONE or CUSTOM
+
+#### Renesas PK - S5D9 selection-With ODS
+# add_definitions( -DTS_SERVICE_TS_CBOR )     	# TS_JSON, TS_CBOR or CUSTOM
+# add_definitions( -DTS_TRANSPORT_MQTT )      	# MQTT or CUSTOM
+# add_definitions( -DTS_SECURITY_CUSTOM )       # MBED, MOCANA, NONE or CUSTOM
+# add_definitions( -DTS_CONTROLLER_CUSTOM )    	# MONARCH, NONE or CUSTOM
+# add_definitions( -DTS_FIREWALL_CUSTOM )       # NONE or CUSTOM 
+# add_definitions( -DTS_MUTEX_NONE )          	# NONE or CUSTOM
+# add_definitions( -DTS_SCEP_CUSTOM )			# NONE or CUSTOM
+
+#### ST Micro selection 
+# add_definitions( -DTS_SERVICE_TS_JSON )     	# TS_JSON, TS_CBOR or CUSTOM
+# add_definitions( -DTS_TRANSPORT_MQTT )      	# MQTT or CUSTOM
+# add_definitions( -DTS_SECURITY_MBED )       	# MBED, MOCANA, NONE or CUSTOM
+# add_definitions( -DTS_CONTROLLER_MONARCH )    # MONARCH, NONE or CUSTOM
+# add_definitions( -DTS_FIREWALL_NONE )       	# NONE or CUSTOM 
+# add_definitions( -DTS_MUTEX_NONE )          	# NONE or CUSTOM
+
+#### NXP selection 
+# add_definitions( -DTS_SERVICE_TS_JSON )     	# TS_JSON, TS_CBOR or CUSTOM
+# add_definitions( -DTS_TRANSPORT_MQTT )      	# MQTT or CUSTOM
+# add_definitions( -DTS_SECURITY_MBED )       	# MBED, MOCANA, NONE or CUSTOM
+# add_definitions( -DTS_CONTROLLER_MONARCH )    # MONARCH, NONE or CUSTOM
+# add_definitions( -DTS_FIREWALL_NONE )       	# NONE or CUSTOM 
+# add_definitions( -DTS_MUTEX_NONE )          	# NONE or CUSTOM
 
 # build vendor libraries
 add_definitions( -D__GLIBC__ )              # TODO, remove tinyCBOR HACK


### PR DESCRIPTION
The CMakelists.txt contains configurations for each platform and usecase. The User/QA Team must use only the provided configuration and no other variants.
This should be done by uncommenting the required configuration before building the SDK.