### PR TITLE
lightweight encryption

### DIFF
--- a/examples/applications/simple/main.c
+++ b/examples/applications/simple/main.c
@@ -57,7 +57,9 @@ static TsStatus_t ts_scep_function(){
 	TsScepConfigRef_t *pConfig= &Config;
 	/*enrol renew and rekey calling example */
 	ts_scepconfig_restore(pConfig, "/var/lib/thingspace/","scepconfig");
-	ts_scep_enroll(pConfig, scep_ca);
+	ts_scepconfig_save(pConfig, "/var/lib/thingspace/","scepconfig");
+    ts_platform_assert(0);
+	//ts_scep_enroll(pConfig, scep_ca);
 	//ts_scep_enroll(pConfig, scep_renew);
 	g_scep_complete = true;
 	ts_status_debug("Exiting Thread now\r\n");
@@ -112,7 +114,8 @@ int main( int argc, char *argv[] ) {
 	ts_service_create( &service );
 
 	
-	
+	// TEST TEST TEST
+	ts_scep_function();
 	
 	ts_status_debug( "simple: initializing certificates,...\n");
 	g_useOpCert = ts_check_opcert_available();

--- a/examples/applications/simple/main.c
+++ b/examples/applications/simple/main.c
@@ -57,9 +57,7 @@ static TsStatus_t ts_scep_function(){
 	TsScepConfigRef_t *pConfig= &Config;
 	/*enrol renew and rekey calling example */
 	ts_scepconfig_restore(pConfig, "/var/lib/thingspace/","scepconfig");
-	ts_scepconfig_save(pConfig, "/var/lib/thingspace/","scepconfig");
-    ts_platform_assert(0);
-	//ts_scep_enroll(pConfig, scep_ca);
+	ts_scep_enroll(pConfig, scep_ca);
 	//ts_scep_enroll(pConfig, scep_renew);
 	g_scep_complete = true;
 	ts_status_debug("Exiting Thread now\r\n");
@@ -114,8 +112,7 @@ int main( int argc, char *argv[] ) {
 	ts_service_create( &service );
 
 	
-	// TEST TEST TEST
-	ts_scep_function();
+	
 	
 	ts_status_debug( "simple: initializing certificates,...\n");
 	g_useOpCert = ts_check_opcert_available();

--- a/sdk/include/ts_cert.h
+++ b/sdk/include/ts_cert.h
@@ -30,7 +30,7 @@ typedef struct TsScepConfig * TsScepConfigRef_t;
 /*
  * REMEMBER - If you edit the structure (add/remove fields) change this string below
  */
-#define SCEP_CONFIG_REV "083018-1"
+#define SCEP_CONFIG_REV "092818-1"
 
 typedef struct TsScepConfig {
 	bool _enabled;			// Specifies if certificate auto-renewal is enable/disable on the device


### PR DESCRIPTION
Changed rev for the scepconfig save file so that non-encrypted scepconfigs wont attempt to be decrypted.
Restore will fail if the file is in the unencrypted format.