### PR TITLE
Npdotf 464 oem logging

### DIFF
--- a/examples/applications/simple/main.c
+++ b/examples/applications/simple/main.c
@@ -183,7 +183,9 @@ int main( int argc, char *argv[] ) {
 		uint64_t timestamp = ts_platform_time();
 		uint32_t interval = 1 * TS_TIME_SEC_TO_USEC;
 
+#ifdef TEST_OEM_LOGGING
 		TsLogConfigRef_t logconfig = ts_service_get_logconfig( service );
+#endif /* TEST_OEM_LOGGING */
 
 		do {
 
@@ -226,7 +228,9 @@ int main( int argc, char *argv[] ) {
 
 			}
 
+#ifdef TEST_OEM_LOGGING
 			ts_log(logconfig, TsLogLevelInfo, TsCategoryDiagnostic, "Testing the OEM-accessible logging capability\n");
+#endif /* TEST_OEM_LOGGING */
 
 			// provide client w/some processing power
 			// note - this will run continuously until the interval is complete

--- a/examples/applications/simple/main.c
+++ b/examples/applications/simple/main.c
@@ -11,6 +11,7 @@
 #include "ts_file.h"
 #include "ts_cert.h"
 #include "ts_scep.h"
+#include "ts_log.h"
 
 #ifdef DO_IT_THE_OLD_WAY
 #include "include/cacert.h"
@@ -181,6 +182,9 @@ int main( int argc, char *argv[] ) {
 		ts_status_debug( "simple: entering run-loop,...\n");
 		uint64_t timestamp = ts_platform_time();
 		uint32_t interval = 1 * TS_TIME_SEC_TO_USEC;
+
+		TsLogConfigRef_t logconfig = ts_service_get_logconfig();
+
 		do {
 
 			// perform update at particular delta
@@ -221,6 +225,8 @@ int main( int argc, char *argv[] ) {
 				}
 
 			}
+
+			ts_log(logconfig, TsLogLevelInfo, TsCategoryDiagnostic, "Testing the OEM-accessible logging capability\n");
 
 			// provide client w/some processing power
 			// note - this will run continuously until the interval is complete

--- a/examples/applications/simple/main.c
+++ b/examples/applications/simple/main.c
@@ -183,7 +183,7 @@ int main( int argc, char *argv[] ) {
 		uint64_t timestamp = ts_platform_time();
 		uint32_t interval = 1 * TS_TIME_SEC_TO_USEC;
 
-		TsLogConfigRef_t logconfig = ts_service_get_logconfig();
+		TsLogConfigRef_t logconfig = ts_service_get_logconfig( service );
 
 		do {
 

--- a/sdk/include/ts_service.h
+++ b/sdk/include/ts_service.h
@@ -312,6 +312,8 @@ TsStatus_t ts_service_hangup( TsServiceRef_t );
 TsStatus_t ts_service_enqueue( TsServiceRef_t, TsMessageRef_t );
 TsStatus_t ts_service_dequeue( TsServiceRef_t, TsServiceAction_t, TsServiceHandler_t );
 TsStatus_t ts_service_enqueue_typed( TsServiceRef_t, char*, TsMessageRef_t );
+
+TsLogConfigRef_t ts_service_get_logconfig();
 #ifdef __cplusplus
 }
 #endif

--- a/sdk/include/ts_service.h
+++ b/sdk/include/ts_service.h
@@ -313,7 +313,7 @@ TsStatus_t ts_service_enqueue( TsServiceRef_t, TsMessageRef_t );
 TsStatus_t ts_service_dequeue( TsServiceRef_t, TsServiceAction_t, TsServiceHandler_t );
 TsStatus_t ts_service_enqueue_typed( TsServiceRef_t, char*, TsMessageRef_t );
 
-TsLogConfigRef_t ts_service_get_logconfig();
+TsLogConfigRef_t ts_service_get_logconfig( TsServiceRef_t );
 #ifdef __cplusplus
 }
 #endif

--- a/sdk/source/ts_service.c
+++ b/sdk/source/ts_service.c
@@ -61,7 +61,7 @@ TsStatus_t ts_service_destroy( TsServiceRef_t service ) {
 
 // Get the LogConfigRef_t object associated with this service, if it exists.
 // Return null if there is none.
-TsLogConfigRef_t ts_service_get_logconfig() {
+TsLogConfigRef_t ts_service_get_logconfig( TsServiceRef_t service ) {
 	return service->_logconfig;
 }
 

--- a/sdk/source/ts_service.c
+++ b/sdk/source/ts_service.c
@@ -59,6 +59,12 @@ TsStatus_t ts_service_destroy( TsServiceRef_t service ) {
 	bool suspend = false;
 #endif
 
+// Get the LogConfigRef_t object associated with this service, if it exists.
+// Return null if there is none.
+TsLogConfigRef_t ts_service_get_logconfig() {
+	return service->_logconfig;
+}
+
 TsStatus_t ts_service_tick( TsServiceRef_t service, uint32_t budget ) {
 
 	ts_status_trace( "ts_service_tick\n" );


### PR DESCRIPTION
This change puts in a new service function, ts_service_get_logconfig(), that just returns the currently active logging configuration so that the caller can access it. This allows an OEM developer to access the ODS logging functionality without modifying the service code to put the logging object into their code module. There is some (disabled) example code in main that uses it to log a test message.

There's no real need to add this to vector tables since it won't have anything to do with the detailed implementation of the service.
